### PR TITLE
Deuxième version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,14 @@
 - Résumé
 - Cote (pas ISBN)
 
+### Mise à jour 2025.09.24
+On désire garder seulement :
+- Image
+- Titre (sans l'auteur dans le titre)
+- Auteur
+- Résumé
+- Cote (pas ISBN)
+
 ## Format d'entrée
 
 - HTML (téléchargé depuis le catalogue en ligne)
@@ -22,6 +30,12 @@
 
 ## Utilisation
 
+Commencer par cloner le repo. Les commandes ci-dessous doivent être roulées depuis le root du repo.
+
+L'utilisation d'un environnement virtuel de Python ("venv") est recommandé pour gérer les dépendances de ce projet séparément des packages installés globalement.
+
+- `python3 -m venv venv`
+- `source venv/bin/activate` (ou l'équivalent sur votre système)
 - `python3 -m pip install -r requirements.txt` (à faire qu'une seule fois)
 - `python3 script.py <fichier.html>`
 
@@ -29,6 +43,8 @@
 
 La génération de l'exécutable requiert Python 3 et les dépendances, mais l'utilisation de l'exécutable ne dépendera pas de la présence de Python sur l'ordinateur.
 
+Ne pas oublier de remplacer `<path/to/pandoc>` dans la commande ci-dessous par l'emplacement de votre exécutable `pandoc`.
+(Exemple de `<path/to/pandoc>` dans un venv : `venv/lib/python3.13/site-packages/pypandoc/files/pandoc`)
+
 - `pyinstaller --onefile --add-binary "<path/to/pandoc>:pypandoc/files/" script.py`
 
-(exemple de <path/to/pandoc> dans un venv : `venv/lib/python3.13/site-packages/pypandoc/files/pandoc`)

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ On désire garder seulement :
 Commencer par cloner le repo. Les commandes ci-dessous doivent être roulées depuis le root du repo.
 
 L'utilisation d'un environnement virtuel de Python ("venv") est recommandé pour gérer les dépendances de ce projet séparément des packages installés globalement.
+Pour les commandes ci-dessous, `python3` est utilisé à titre d'exemple - `python` peut être utilisé s'il pointe vers Python 3 dans l'environnement virtuel.
 
 - `python3 -m venv venv`
 - `source venv/bin/activate` (ou l'équivalent sur votre système)
@@ -44,7 +45,9 @@ L'utilisation d'un environnement virtuel de Python ("venv") est recommandé pour
 La génération de l'exécutable requiert Python 3 et les dépendances, mais l'utilisation de l'exécutable ne dépendera pas de la présence de Python sur l'ordinateur.
 
 Ne pas oublier de remplacer `<path/to/pandoc>` dans la commande ci-dessous par l'emplacement de votre exécutable `pandoc`.
-(Exemple de `<path/to/pandoc>` dans un venv : `venv/lib/python3.13/site-packages/pypandoc/files/pandoc`)
+(Exemple de `<path/to/pandoc>` dans un venv sur Windows : `venv/Lib/site-packages/pypandoc/files/pandoc.exe`)
+
+Les guillemets autour de `<path/to/pandoc>:pypandoc/files/` sont requis dans la commande.
 
 - `pyinstaller --onefile --add-binary "<path/to/pandoc>:pypandoc/files/" script.py`
 

--- a/script.py
+++ b/script.py
@@ -15,8 +15,10 @@ if getattr(sys, 'frozen', False):
 
 
 def download_replace_images(soup):
-    if sys.platform == "darwin":
-        # Give up verifying certificates
+    if True:  # sys.platform == "darwin":
+        # Give up verifying certificates on every platform
+        # Only because the library's website's certificate isn't "trusted",
+        # but it's actually fine when opening in a browser?
         context = ssl._create_unverified_context()
     else:
         context = ssl.create_default_context()


### PR DESCRIPTION
- Retrait du champ Description et Éditeur
- Clean up du titre pour enlever la mention de l'auteur(e) (l'info se trouve dans un champ plus bas)
- Ne vérifie plus les certificats lors du téléchargement des images
  - (J'ai peut-être fait une erreur lors de mon premier commit pour la "Première version" - je pense que l'exécutable v1.0.0 ne faisait déjà pas la vérification dans Windows)
- Les images sont téléchargées dans un dossier temporaire (on ne verra plus un dossier "images" apparaître puis disparaître)
- Amélioration du README